### PR TITLE
Feature/Added QR code in share survey modal #308

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.2.0",
+        "react-qr-code": "^2.0.15",
         "react-tooltip": "^5.25.1",
         "recharts": "^2.4.3",
         "sass": "^1.52.1",
@@ -11387,6 +11388,12 @@
         }
       ]
     },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
@@ -11503,6 +11510,19 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.15.tgz",
+      "integrity": "sha512-MkZcjEXqVKqXEIMVE0mbcGgDpkfSdd8zhuzXEl9QzYeNcw8Hq2oVIzDLWuZN2PQBwM5PWjc2S31K8Q1UbcFMfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-redux": {
       "version": "7.2.9",
@@ -21956,6 +21976,11 @@
       "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
       "dev": true
     },
+    "qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+    },
     "qs": {
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
@@ -22035,6 +22060,15 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-qr-code": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.15.tgz",
+      "integrity": "sha512-MkZcjEXqVKqXEIMVE0mbcGgDpkfSdd8zhuzXEl9QzYeNcw8Hq2oVIzDLWuZN2PQBwM5PWjc2S31K8Q1UbcFMfw==",
+      "requires": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      }
     },
     "react-redux": {
       "version": "7.2.9",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.2.0",
+    "react-qr-code": "^2.0.15",
     "react-tooltip": "^5.25.1",
     "recharts": "^2.4.3",
     "sass": "^1.52.1",

--- a/src/features/surveys/components/ShareSurveryModal/ShareSurveyModal.tsx
+++ b/src/features/surveys/components/ShareSurveryModal/ShareSurveyModal.tsx
@@ -4,6 +4,7 @@ import Button, { ButtonVariant } from 'shared/components/Button/Button';
 import StyledDialog from 'shared/components/StyledDialog/StyledDialog';
 import useTranslation from 'next-translate/useTranslation';
 import useCopyToClipboard from 'shared/hooks/useCopyToClipboard';
+import QRCode from 'react-qr-code';
 
 type ShareSurveyModalProps = {
   surveyId: string;
@@ -32,6 +33,16 @@ export default function ShareSurveyModal({
       title={t('shareSurveyModal.title')}
       content={
         <>
+          <div className="mt-4 flex justify-center">
+            <div className="w-1/2">
+              <QRCode
+                size={256}
+                style={{ height: 'auto', maxWidth: '100%', width: '100%' }}
+                value={link}
+              />
+            </div>
+          </div>
+
           <div className="mt-4">
             <span className="scrollbar-hide block w-full select-all overflow-x-auto whitespace-nowrap rounded-md border border-gray-300 px-3 py-2 text-center text-sm focus:outline-none">
               {link}


### PR DESCRIPTION
Implemented QR code generation in the survey share modal. The QR code encodes the survey URL for easier sharing. I tried to use [qrcodejs](https://www.npmjs.com/package/qrcodejs), but it was not working and I believe it was developed for native HTML/JS code. So I used [react-qr-code](https://www.npmjs.com/package/react-qr-code) for QR code generation. Tested on various devices to ensure proper rendering. You can also check the image snapshots of the survey modal with QR code.

[Image 1](https://snipboard.io/3Ft8y6.jpg)
[Image 2](https://snipboard.io/o9zX4Y.jpg)